### PR TITLE
Add initial Python SDK support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,21 @@ npm/bin/muapi-linux-x86_64
 npm/bin/muapi-linux-arm64
 npm/bin/muapi-windows-x86_64.exe
 .DS_Store
+# Local SDK testing files
+test_all.py
+test_predictions.py
+test_req.py
+test_sdk.py
+test_sdk_videos.py
+test_uploads.py
+
+# Local test assets
+image.png
+
+# Python cache
+__pycache__/
+*.pyc
+
+# Virtual environments
+venv/
+.venv/

--- a/README.md
+++ b/README.md
@@ -49,7 +49,39 @@ muapi account balance
 # Wait for an existing job
 muapi predict wait <request_id>
 ```
+## Python SDK
 
+Generate an image:
+
+```python
+from muapi import MuAPI
+
+client = MuAPI()
+
+result = client.images.generate(
+    prompt="A futuristic city at sunset",
+    model="flux-dev"
+)
+
+print(result)
+
+```
+
+Generate a video:
+
+```python
+from muapi import MuAPI
+
+client = MuAPI()
+
+result = client.videos.generate(
+    prompt="A dragon flying through clouds",
+    model="kling-master",
+    wait=False
+)
+
+print(result)
+```
 ## Commands
 
 ### `muapi auth`

--- a/examples/image_edit.py
+++ b/examples/image_edit.py
@@ -1,0 +1,11 @@
+from muapi import MuAPI
+
+client = MuAPI()
+
+result = client.images.edit(
+    prompt="Convert this image into anime style",
+    image="https://example.com/image.jpg",
+    model="flux-kontext-dev"
+)
+
+print(result)

--- a/examples/image_generate.py
+++ b/examples/image_generate.py
@@ -1,0 +1,10 @@
+from muapi import MuAPI
+
+client = MuAPI()
+
+result = client.images.generate(
+    prompt="A futuristic city at sunset",
+    model="flux-dev"
+)
+
+print(result)

--- a/examples/prediction_wait.py
+++ b/examples/prediction_wait.py
@@ -1,0 +1,16 @@
+from muapi import MuAPI
+
+client = MuAPI()
+
+job = client.videos.generate(
+    prompt="A cinematic shot of a spaceship",
+    wait=False
+)
+
+request_id = job["request_id"]
+
+result = client.predictions.wait(
+    request_id
+)
+
+print(result)

--- a/examples/upload_file.py
+++ b/examples/upload_file.py
@@ -1,0 +1,9 @@
+from muapi import MuAPI
+
+client = MuAPI()
+
+result = client.uploads.upload(
+    "image.png"
+)
+
+print(result)

--- a/examples/video_generate.py
+++ b/examples/video_generate.py
@@ -1,0 +1,11 @@
+from muapi import MuAPI
+
+client = MuAPI()
+
+result = client.videos.generate(
+    prompt="A dragon flying through clouds",
+    model="kling-master",
+    wait=False
+)
+
+print(result)

--- a/muapi/__init__.py
+++ b/muapi/__init__.py
@@ -1,1 +1,3 @@
 __version__ = "0.2.0"
+
+from .sdk import MuAPI

--- a/muapi/accounts.py
+++ b/muapi/accounts.py
@@ -1,0 +1,48 @@
+import httpx
+
+from .config import BASE_URL, get_api_key
+from .client import MuapiError
+
+
+class AccountAPI:
+    def _headers(self):
+        key = get_api_key()
+
+        if not key:
+            raise MuapiError(
+                "No API key configured. Run: muapi auth configure"
+            )
+
+        return {"x-api-key": key}
+
+    def balance(self):
+        resp = httpx.get(
+            f"{BASE_URL}/account/balance",
+            headers=self._headers(),
+            timeout=30.0,
+        )
+
+        if resp.status_code >= 400:
+            raise MuapiError(resp.text, resp.status_code)
+
+        return resp.json()
+
+    def topup(
+        self,
+        amount: int,
+        currency: str = "usd",
+    ):
+        resp = httpx.post(
+            f"{BASE_URL}/account/topup",
+            json={
+                "amount": amount,
+                "currency": currency.lower(),
+            },
+            headers=self._headers(),
+            timeout=30.0,
+        )
+
+        if resp.status_code >= 400:
+            raise MuapiError(resp.text, resp.status_code)
+
+        return resp.json()

--- a/muapi/audio.py
+++ b/muapi/audio.py
@@ -1,0 +1,98 @@
+from . import client
+
+
+class AudioAPI:
+    def create(
+        self,
+        prompt: str,
+        title: str = "",
+        tags: str = "",
+        instrumental: bool = False,
+        wait: bool = True,
+    ):
+        payload = {
+            "prompt": prompt,
+            "title": title,
+            "tags": tags,
+            "make_instrumental": instrumental,
+        }
+
+        return client.generate(
+            "suno-create-music",
+            payload,
+            wait=wait,
+        )
+
+    def remix(
+        self,
+        song_id: str,
+        prompt: str = "",
+        title: str = "",
+        tags: str = "",
+        wait: bool = True,
+    ):
+        payload = {
+            "song_id": song_id,
+            "prompt": prompt,
+            "title": title,
+            "tags": tags,
+        }
+
+        return client.generate(
+            "suno-remix-music",
+            payload,
+            wait=wait,
+        )
+
+    def extend(
+        self,
+        song_id: str,
+        prompt: str = "",
+        continue_at: float = 0,
+        wait: bool = True,
+    ):
+        payload = {
+            "song_id": song_id,
+            "prompt": prompt,
+            "continue_at": continue_at,
+        }
+
+        return client.generate(
+            "suno-extend-music",
+            payload,
+            wait=wait,
+        )
+
+    def from_text(
+        self,
+        prompt: str,
+        duration: float = 10.0,
+        wait: bool = True,
+    ):
+        payload = {
+            "prompt": prompt,
+            "duration": duration,
+        }
+
+        return client.generate(
+            "mmaudio-v2/text-to-audio",
+            payload,
+            wait=wait,
+        )
+
+    def from_video(
+        self,
+        video_url: str,
+        prompt: str = "",
+        wait: bool = True,
+    ):
+        payload = {
+            "video_url": video_url,
+            "prompt": prompt,
+        }
+
+        return client.generate(
+            "mmaudio-v2/video-to-video",
+            payload,
+            wait=wait,
+        )

--- a/muapi/edit.py
+++ b/muapi/edit.py
@@ -1,0 +1,116 @@
+from . import client
+
+
+class EditAPI:
+    def effects(
+        self,
+        effect: str,
+        mode: str = "video",
+        video_url: str = None,
+        image_url: str = None,
+        wait: bool = True,
+    ):
+        if mode == "wan":
+            endpoint = "generate_wan_ai_effects"
+            payload = {
+                "image_url": image_url,
+                "effect": effect,
+            }
+
+        elif mode == "image":
+            endpoint = "image-effects"
+            payload = {
+                "image_url": image_url,
+                "effect": effect,
+            }
+
+        else:
+            endpoint = "video-effects"
+            payload = {
+                "video_url": video_url,
+                "effect": effect,
+            }
+
+        return client.generate(
+            endpoint,
+            payload,
+            wait=wait,
+        )
+
+    def lipsync(
+        self,
+        video_url: str,
+        audio_url: str,
+        model: str = "sync",
+        wait: bool = True,
+    ):
+        endpoint_map = {
+            "sync": "sync-lipsync",
+            "latentsync": "latentsync-video",
+            "creatify": "creatify-lipsync",
+            "veed": "veed-lipsync",
+            "ltx-2": "ltx-2-19b-lipsync",
+            "ltx-2.3": "ltx-2.3-lipsync",
+            "kling-v1": "kling-v1-avatar-pro",
+            "kling-v2": "kling-v2-avatar-pro",
+            "wan2.2": "wan2.2-speech-to-video",
+        }
+
+        if model not in endpoint_map:
+            raise ValueError(f"Unknown model: {model}")
+
+        return client.generate(
+            endpoint_map[model],
+            {
+                "video_url": video_url,
+                "audio_url": audio_url,
+            },
+            wait=wait,
+        )
+
+    def dance(
+        self,
+        image_url: str,
+        video_url: str,
+        wait: bool = True,
+    ):
+        return client.generate(
+            "ai-dance-effects",
+            {
+                "image_url": image_url,
+                "video_url": video_url,
+            },
+            wait=wait,
+        )
+
+    def dress(
+        self,
+        image_url: str,
+        dress_url: str,
+        wait: bool = True,
+    ):
+        return client.generate(
+            "ai-dress-change",
+            {
+                "model_image_url": image_url,
+                "garment_image_url": dress_url,
+            },
+            wait=wait,
+        )
+
+    def clipping(
+        self,
+        video_url: str,
+        num_highlights: int = 3,
+        aspect_ratio: str = "9:16",
+        wait: bool = True,
+    ):
+        return client.generate(
+            "ai-clipping",
+            {
+                "video_url": video_url,
+                "num_highlights": num_highlights,
+                "aspect_ratio": aspect_ratio,
+            },
+            wait=wait,
+        )

--- a/muapi/enhance.py
+++ b/muapi/enhance.py
@@ -1,0 +1,136 @@
+from . import client
+
+
+class EnhanceAPI:
+    def upscale(
+        self,
+        image_url: str,
+        wait: bool = True,
+    ):
+        return client.generate(
+            "ai-image-upscale",
+            {"image_url": image_url},
+            wait=wait,
+        )
+
+    def remove_background(
+        self,
+        image_url: str,
+        wait: bool = True,
+    ):
+        return client.generate(
+            "ai-background-remover",
+            {"image_url": image_url},
+            wait=wait,
+        )
+
+    def face_swap(
+        self,
+        source_url: str,
+        target_url: str,
+        mode: str = "image",
+        wait: bool = True,
+    ):
+        endpoint = (
+            "ai-video-face-swap"
+            if mode == "video"
+            else "ai-image-face-swap"
+        )
+
+        return client.generate(
+            endpoint,
+            {
+                "source_url": source_url,
+                "target_url": target_url,
+            },
+            wait=wait,
+        )
+
+    def skin(
+        self,
+        image_url: str,
+        wait: bool = True,
+    ):
+        return client.generate(
+            "ai-skin-enhancer",
+            {"image_url": image_url},
+            wait=wait,
+        )
+
+    def colorize(
+        self,
+        image_url: str,
+        wait: bool = True,
+    ):
+        return client.generate(
+            "ai-color-photo",
+            {"image_url": image_url},
+            wait=wait,
+        )
+
+    def ghibli(
+        self,
+        image_url: str,
+        wait: bool = True,
+    ):
+        return client.generate(
+            "ai-ghibli-style",
+            {"image_url": image_url},
+            wait=wait,
+        )
+
+    def anime(
+        self,
+        image_url: str,
+        prompt: str = "",
+        wait: bool = True,
+    ):
+        return client.generate(
+            "ai-anime-generator",
+            {
+                "image_url": image_url,
+                "prompt": prompt,
+            },
+            wait=wait,
+        )
+
+    def extend(
+        self,
+        image_url: str,
+        wait: bool = True,
+    ):
+        return client.generate(
+            "ai-image-extension",
+            {"image_url": image_url},
+            wait=wait,
+        )
+
+    def product_shot(
+        self,
+        image_url: str,
+        background_prompt: str = "",
+        wait: bool = True,
+    ):
+        return client.generate(
+            "ai-product-shot",
+            {
+                "image_url": image_url,
+                "scene_description": background_prompt,
+            },
+            wait=wait,
+        )
+
+    def erase(
+        self,
+        image_url: str,
+        mask_url: str,
+        wait: bool = True,
+    ):
+        return client.generate(
+            "ai-object-eraser",
+            {
+                "image_url": image_url,
+                "mask_image_url": mask_url,
+            },
+            wait=wait,
+        )

--- a/muapi/images.py
+++ b/muapi/images.py
@@ -1,0 +1,66 @@
+from . import client
+from .commands.image import (
+    T2I_MODELS,
+    I2I_MODELS,
+    LIST_INPUT_MODELS,
+)
+
+
+class ImagesAPI:
+    def generate(
+        self,
+        prompt: str,
+        model: str = "flux-dev",
+        wait: bool = True,
+        num_images: int = 1,
+        width: int = 1024,
+        height: int = 1024,
+    ):
+        if model not in T2I_MODELS:
+            raise ValueError(f"Unknown model: {model}")
+
+        endpoint = T2I_MODELS[model]
+
+        payload = {
+            "prompt": prompt,
+            "num_images": num_images,
+            "width": width,
+            "height": height,
+        }
+
+        return client.generate(
+            endpoint,
+            payload,
+            wait=wait,
+        )
+
+    def edit(
+        self,
+        prompt: str,
+        image: str,
+        model: str = "flux-kontext-dev",
+        wait: bool = True,
+        num_images: int = 1,
+        aspect_ratio: str = "1:1",
+    ):
+        if model not in I2I_MODELS:
+            raise ValueError(f"Unknown model: {model}")
+
+        endpoint = I2I_MODELS[model]
+
+        payload = {
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "num_images": num_images,
+        }
+
+        if model in LIST_INPUT_MODELS:
+            payload["images_list"] = [image]
+        else:
+            payload["image_url"] = image
+
+        return client.generate(
+            endpoint,
+            payload,
+            wait=wait,
+        )

--- a/muapi/models.py
+++ b/muapi/models.py
@@ -1,0 +1,29 @@
+from .commands.models import _ALL_MODELS
+
+
+class ModelsAPI:
+    def list(self, category: str = "all"):
+        if category == "all":
+            return _ALL_MODELS
+
+        result = {}
+
+        for cat, models in _ALL_MODELS.items():
+            if cat.startswith(category):
+                result[cat] = models
+
+        return result
+
+    def get(self, model_name: str):
+        for category, models in _ALL_MODELS.items():
+            if model_name in models:
+                return {
+                    "name": model_name,
+                    "category": category,
+                    "endpoint": models[model_name],
+                }
+
+        raise ValueError(f"Model '{model_name}' not found")
+
+    def categories(self):
+        return list(_ALL_MODELS.keys())

--- a/muapi/predictions.py
+++ b/muapi/predictions.py
@@ -1,0 +1,12 @@
+from .client import (
+    get_result,
+    wait_for_result,
+)
+
+
+class PredictionsAPI:
+    def get(self, request_id: str):
+        return get_result(request_id)
+
+    def wait(self, request_id: str):
+        return wait_for_result(request_id)

--- a/muapi/sdk.py
+++ b/muapi/sdk.py
@@ -1,0 +1,12 @@
+from .images import ImagesAPI
+from .videos import VideosAPI
+from .uploads import UploadsAPI
+from .predictions import PredictionsAPI
+
+
+class MuAPI:
+    def __init__(self):
+        self.images = ImagesAPI()
+        self.videos = VideosAPI()
+        self.uploads = UploadsAPI()
+        self.predictions = PredictionsAPI()

--- a/muapi/sdk.py
+++ b/muapi/sdk.py
@@ -2,11 +2,20 @@ from .images import ImagesAPI
 from .videos import VideosAPI
 from .uploads import UploadsAPI
 from .predictions import PredictionsAPI
-
-
+from .audio import AudioAPI
+from .models import ModelsAPI
+from .accounts import AccountAPI
+from .edit import EditAPI
+from .enhance import EnhanceAPI
 class MuAPI:
     def __init__(self):
         self.images = ImagesAPI()
         self.videos = VideosAPI()
         self.uploads = UploadsAPI()
         self.predictions = PredictionsAPI()
+        self.audio = AudioAPI()
+        self.models = ModelsAPI()
+        self.account=AccountAPI()
+        self.edit=EditAPI()
+        self.enhance=EnhanceAPI()
+        

--- a/muapi/uploads.py
+++ b/muapi/uploads.py
@@ -1,0 +1,6 @@
+from .client import upload_file
+
+
+class UploadsAPI:
+    def upload(self, file_path: str):
+        return upload_file(file_path)

--- a/muapi/videos.py
+++ b/muapi/videos.py
@@ -1,0 +1,64 @@
+from . import client
+from .commands.video import (
+    T2V_MODELS,
+    I2V_MODELS,
+    LIST_INPUT_I2V,
+)
+
+
+class VideosAPI:
+    def generate(
+        self,
+        prompt: str,
+        model: str = "kling-master",
+        wait: bool = True,
+        duration: int = 5,
+        aspect_ratio: str = "16:9",
+    ):
+        if model not in T2V_MODELS:
+            raise ValueError(f"Unknown model: {model}")
+
+        endpoint = T2V_MODELS[model]
+
+        payload = {
+            "prompt": prompt,
+            "duration": duration,
+            "aspect_ratio": aspect_ratio,
+        }
+
+        return client.generate(
+            endpoint,
+            payload,
+            wait=wait,
+        )
+
+    def from_image(
+        self,
+        prompt: str,
+        image: str,
+        model: str = "kling-std",
+        wait: bool = True,
+        duration: int = 5,
+        aspect_ratio: str = "16:9",
+    ):
+        if model not in I2V_MODELS:
+            raise ValueError(f"Unknown model: {model}")
+
+        endpoint = I2V_MODELS[model]
+
+        payload = {
+            "prompt": prompt,
+            "duration": duration,
+            "aspect_ratio": aspect_ratio,
+        }
+
+        if model in LIST_INPUT_I2V:
+            payload["images_list"] = [image]
+        else:
+            payload["image_url"] = image
+
+        return client.generate(
+            endpoint,
+            payload,
+            wait=wait,
+        )


### PR DESCRIPTION
## Summary

This PR introduces an initial Python SDK for MuAPI, providing a programmatic interface on top of the existing client implementation.

## Features Added

### Images

* `client.images.generate()`
* `client.images.edit()`

### Videos

* `client.videos.generate()`
* `client.videos.from_image()`

### Uploads

* `client.uploads.upload()`

### Predictions

* `client.predictions.get()`
* `client.predictions.wait()`

## Example Usage

```python
from muapi import MuAPI

client = MuAPI()

result = client.images.generate(
    prompt="A futuristic city at sunset"
)

print(result)
```

## Additional Changes

* Added SDK entry point via `MuAPI`
* Added usage examples under the `examples/` directory
* Updated README with Python SDK documentation
* Reused existing `client.py` request and polling logic to avoid code duplication

## Notes

This is an initial SDK implementation focused on providing a clean Python interface while maintaining compatibility with the existing CLI architecture.
